### PR TITLE
Fixed typo in get_nuke_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,7 @@ ___
 
 HOW TO USE
 ---
-Video tutorial is coming soon.
+Tutorials on Youtube: https://www.youtube.com/watch?v=EaccWOZxJYA&t=204s
+
+Tutorial on personal site: http://www.fatihunal.net/tutorials/nodes_operator_for_nuke/ 
 

--- a/menu.py
+++ b/menu.py
@@ -3,13 +3,14 @@ import node_operator_main_v01
 import importlib
 
 
-toolbar = nuke.menu("Nodes")
-i = toolbar.addMenu("Studio")
+# toolbar = nuke.menu("Nodes")
+# i = toolbar.addMenu("Studio")
+i = nuke.menu("Nuke")
 
 # development node operator
 def start_NOP():
     # node operator
     importlib.reload(node_operator_main_v01)
     node_operator_main_v01.start()
-i.addCommand("Node Operator v0.1", "start_NOP()")
+i.addCommand("CGEV Tools/Node Operator v0.1", "start_NOP()", "alt+o")
 

--- a/menu.py
+++ b/menu.py
@@ -1,6 +1,6 @@
 import nuke
 import node_operator_main_v01
-import importlib
+import imp
 
 
 # toolbar = nuke.menu("Nodes")
@@ -10,7 +10,7 @@ i = nuke.menu("Nuke")
 # development node operator
 def start_NOP():
     # node operator
-    importlib.reload(node_operator_main_v01)
+    imp.reload(node_operator_main_v01)
     node_operator_main_v01.start()
 i.addCommand("CGEV Tools/Node Operator v0.1", "start_NOP()", "alt+o")
 

--- a/nodes_operator/general_info.py
+++ b/nodes_operator/general_info.py
@@ -116,7 +116,7 @@ class general_infos(QWidget, Ui_Form):
             nuke_env = "Indie"
         elif nuke.env["nukex"] == True:
             nuke_env = "NukeX"
-        elif nuke_env["hieroStudio"] == True:
+        elif nuke.env["hieroStudio"] == True:
             nuke_env = "Hiero Studio"
         elif nuke.env["hiero"] == True:
             nuke_env = "Hiero"
@@ -126,7 +126,7 @@ class general_infos(QWidget, Ui_Form):
             nuke_env = "Non Commercial"
         elif nuke.env["nukex"] == True:
             nuke_env = "NukeX"
-        elif nuke_env["studio"] == True:
+        elif nuke.env["studio"] == True:
             nuke_env = "Nuke Studio"
         else:
             nuke_env = "Unknow Environment"

--- a/nodes_operator/node_operator_main_v01.py
+++ b/nodes_operator/node_operator_main_v01.py
@@ -14,11 +14,11 @@ import read_node_tab
 import create_write_node
 import ready_expressions
 import general_info
-import importlib
-importlib.reload(read_node_tab)
-importlib.reload(create_write_node)
-importlib.reload(ready_expressions)
-importlib.reload(general_info)
+import imp
+imp.reload(read_node_tab)
+imp.reload(create_write_node)
+imp.reload(ready_expressions)
+imp.reload(general_info)
 
 class nodes_operator(QWidget, Ui_Form):
     def __init__(self):


### PR DESCRIPTION
Tried to call nuke_env instead of nuke.env